### PR TITLE
Add server interface

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -22,3 +22,5 @@
 
 Robert Bosch GmbH
     Stefan Laible <stefan.laible@de.bosch.com>
+
+Robert Willeit <fkml@gmx.de>

--- a/bosch_locator_bridge/CMakeLists.txt
+++ b/bosch_locator_bridge/CMakeLists.txt
@@ -94,10 +94,10 @@ target_link_libraries(${PROJECT_NAME}_node
 )
 
 add_executable(${PROJECT_NAME}_server_node
-  src/server/server_main.cpp
-  src/server/server_bridge_node.cpp
+  src/locator_rpc_interface.cpp
   src/rosmsgs_datagram_converter.cpp
-  src/locator_rpc_interface.cpp)
+  src/server/server_bridge_node.cpp
+  src/server/server_main.cpp)
 set_target_properties(${PROJECT_NAME}_server_node PROPERTIES OUTPUT_NAME server_node PREFIX "")
 add_dependencies(${PROJECT_NAME}_server_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(${PROJECT_NAME}_server_node

--- a/bosch_locator_bridge/CMakeLists.txt
+++ b/bosch_locator_bridge/CMakeLists.txt
@@ -45,6 +45,8 @@ add_service_files(
     ClientMapSet.srv
     ClientMapStart.srv
     StartRecording.srv
+    ServerMapGetImageWithResolution.srv
+    ServerMapList.srv
 )
 
 generate_messages(
@@ -91,9 +93,28 @@ target_link_libraries(${PROJECT_NAME}_node
   Poco::Net
 )
 
+add_executable(${PROJECT_NAME}_server_node
+  src/server/server_main.cpp
+  src/server/server_bridge_node.cpp
+  src/rosmsgs_datagram_converter.cpp
+  src/locator_rpc_interface.cpp)
+set_target_properties(${PROJECT_NAME}_server_node PROPERTIES OUTPUT_NAME server_node PREFIX "")
+add_dependencies(${PROJECT_NAME}_server_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+target_link_libraries(${PROJECT_NAME}_server_node
+  ${catkin_LIBRARIES}
+  Poco::Foundation
+  Poco::JSON
+  Poco::Net
+)
+
 install(TARGETS ${PROJECT_NAME}_node
         RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
+
+install(TARGETS ${PROJECT_NAME}_server_node
+        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
 install(FILES config/locator_bridge_localization.rviz config/locator_bridge_map_creation.rviz config/locator_bridge_visual_recording.rviz
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/config
 )

--- a/bosch_locator_bridge/include/bosch_locator_bridge/enums.hpp
+++ b/bosch_locator_bridge/include/bosch_locator_bridge/enums.hpp
@@ -46,7 +46,7 @@ enum ModuleIdentifier : uint16_t
   SUPPORT_RECOVERY = 0x0301,
 };
 
-std::string stringifyModuleId(ModuleIdentifier id)
+inline std::string stringifyModuleId(ModuleIdentifier id)
 {
   switch (id)
   {
@@ -114,7 +114,7 @@ enum CommonResponseCode : uint64_t
   ENTITY_IN_USE = 0x000000000000000e,
 };
 
-std::string stringifyCommonResponseCode(CommonResponseCode c)
+inline std::string stringifyCommonResponseCode(CommonResponseCode c)
 {
   switch (c)
   {

--- a/bosch_locator_bridge/include/bosch_locator_bridge/server/server_bridge_node.hpp
+++ b/bosch_locator_bridge/include/bosch_locator_bridge/server/server_bridge_node.hpp
@@ -36,7 +36,7 @@ class LocatorRPCInterface;
 class ServerBridgeNode {
 public:
   ServerBridgeNode();
-  ~ServerBridgeNode();
+  virtual ~ServerBridgeNode();
 
   void init();
 

--- a/bosch_locator_bridge/include/bosch_locator_bridge/server/server_bridge_node.hpp
+++ b/bosch_locator_bridge/include/bosch_locator_bridge/server/server_bridge_node.hpp
@@ -1,0 +1,64 @@
+// Copyright (c) 2021 - for information on the respective copyright owner
+// see the NOTICE file and/or the repository
+// https://github.com/boschglobal/locator_ros_bridge.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <unordered_map>
+
+#include <Poco/Thread.h>
+
+#include <ros/ros.h>
+#include <std_srvs/Empty.h>
+
+#include "bosch_locator_bridge/ServerMapGetImageWithResolution.h"
+#include "bosch_locator_bridge/ServerMapList.h"
+
+// forward declarations
+class LocatorRPCInterface;
+
+/**
+ * This is the main ROS node. It binds together the ROS interface and the
+ * Locator API.
+ */
+class ServerBridgeNode {
+public:
+  ServerBridgeNode();
+  ~ServerBridgeNode();
+
+  void init();
+
+private:
+  bool check_module_versions(
+      const std::unordered_map<std::string, std::pair<int32_t, int32_t>>
+          &module_versions);
+
+  bool serverMapListCb(bosch_locator_bridge::ServerMapList::Request &req,
+                       bosch_locator_bridge::ServerMapList::Response &res);
+
+  bool serverMapGetImageWithResolutionCb(
+      bosch_locator_bridge::ServerMapGetImageWithResolution::Request &req,
+      bosch_locator_bridge::ServerMapGetImageWithResolution::Response &res);
+
+  /// read out ROS parameters and use them to update the locator config
+  void syncConfig();
+
+  ros::NodeHandle nh_;
+  std::unique_ptr<LocatorRPCInterface> server_interface_;
+
+  ros::Timer session_refresh_timer_;
+
+  std::vector<ros::ServiceServer> services_;
+};

--- a/bosch_locator_bridge/launch/server_bridge.launch
+++ b/bosch_locator_bridge/launch/server_bridge.launch
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--Copyright (c) 2021 - for information on the respective copyright owner
+see the NOTICE file and/or the repository https://github.com/boschglobal/locator_ros_bridge.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.-->
+
+<launch>
+  <!-- ip of the computer on which the bridge is running -->
+  <arg name="bridge_ip" default="172.17.0.1"/>
+  <!-- ip of the computer, on which the locator software is running -->
+  <arg name="locator_ip" default="127.0.0.1"/>
+
+  <!-- login credentials for the locator software -->
+  <arg name="locator_user" default="admin"/>
+  <arg name="locator_password" default="admin"/>
+
+  <node pkg="bosch_locator_bridge" type="server_node" name="server_bridge_node" output="screen" required="true">
+    <param name="server_host" value="$(arg locator_ip)" />
+
+    <param name="user_name" value="$(arg locator_user)"/>
+    <param name="password" value="$(arg locator_password)"/>
+    
+    <rosparam ns="localization_server_config" subst_value="true">
+
+    </rosparam>
+  </node>
+
+</launch>

--- a/bosch_locator_bridge/src/server/server_bridge_node.cpp
+++ b/bosch_locator_bridge/src/server/server_bridge_node.cpp
@@ -1,0 +1,218 @@
+// Copyright (c) 2021 - for information on the respective copyright owner
+// see the NOTICE file and/or the repository
+// https://github.com/boschglobal/locator_ros_bridge.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "server/server_bridge_node.hpp"
+
+#include "enums.hpp"
+#include "locator_rpc_interface.hpp"
+
+#include "Poco/Base64Decoder.h"
+
+#include <fstream>
+
+/// server module versions to check against. Format is name, { major_version,
+/// minor_version }
+const static std::unordered_map<std::string, std::pair<int32_t, int32_t>>
+    REQUIRED_MODULE_VERSIONS({
+        {"AboutModules", {4, 0}},
+        {"Session", {3, 0}},
+        {"Diagnostic", {4, 0}},
+        {"Licensing", {6, 0}},
+        {"Config", {4, 0}},
+        {"AboutBuild", {3, 0}},
+        {"Certificates", {3, 0}},
+        {"System", {3, 1}},
+        {"ServerMap", {5, 0}},
+        {"ServerInternal", {2, 0}},
+        {"ServerInternal", {4, 0}},
+    });
+
+ServerBridgeNode::ServerBridgeNode() : nh_("~") {}
+
+ServerBridgeNode::~ServerBridgeNode() {}
+
+void ServerBridgeNode::init() {
+  std::string host;
+  nh_.getParam("server_host", host);
+
+  std::string user, pwd;
+  nh_.getParam("user_name", user);
+  nh_.getParam("password", pwd);
+
+  server_interface_.reset(new LocatorRPCInterface(host, 8082));
+  server_interface_->login(user, pwd);
+  session_refresh_timer_ =
+      nh_.createTimer(ros::Duration(30.), [&](const ros::TimerEvent &) {
+        ROS_INFO_STREAM("refreshing session!");
+        server_interface_->refresh();
+      });
+
+  const auto module_versions = server_interface_->getAboutModules();
+  if (!check_module_versions(module_versions)) {
+    throw std::runtime_error("locator software incompatible with this bridge!");
+  }
+
+  syncConfig();
+  services_.push_back(nh_.advertiseService(
+      "list_server_maps", &ServerBridgeNode::serverMapListCb, this));
+  services_.push_back(nh_.advertiseService(
+      "get_map_with_resolution",
+      &ServerBridgeNode::serverMapGetImageWithResolutionCb, this));
+
+  ROS_INFO_STREAM("initialization done");
+}
+
+void ServerBridgeNode::syncConfig() {
+  ROS_INFO_STREAM("syncing config");
+  XmlRpc::XmlRpcValue localization_server_rosconfig;
+  nh_.getParam("localization_server_config", localization_server_rosconfig);
+
+  auto server_config = server_interface_->getConfigList();
+  // overwrite current locator config with ros params
+  for (auto &iter : localization_server_rosconfig) {
+    const auto &key = iter.first;
+    auto &value = iter.second;
+    if (!localization_server_rosconfig.hasMember(key)) {
+      ROS_WARN_STREAM("invalid locator rosparam found: " << key << ", "
+                                                         << value);
+      continue;
+    }
+    ROS_INFO_STREAM("setting value for " << key << ", " << value);
+    switch (value.getType()) {
+    case XmlRpc::XmlRpcValue::TypeBoolean:
+      server_config[key] = static_cast<bool>(value);
+      break;
+    case XmlRpc::XmlRpcValue::TypeInt:
+      server_config[key] = static_cast<int>(value);
+      break;
+    case XmlRpc::XmlRpcValue::TypeDouble:
+      server_config[key] = static_cast<double>(value);
+      break;
+    case XmlRpc::XmlRpcValue::TypeString:
+      server_config[key] = static_cast<std::string>(value);
+      break;
+    // TODO: add missing parameters
+    default:
+      ROS_ERROR_STREAM("unknown config type for " << key);
+      break;
+    }
+  }
+  ROS_INFO_STREAM("new loc client config: " << server_config.toString());
+  for (const auto &c : server_config) {
+    ROS_INFO_STREAM("- " << c.first << ": " << c.second.toString());
+  }
+
+  server_interface_->setConfigList(server_config);
+}
+
+bool ServerBridgeNode::check_module_versions(
+    const std::unordered_map<std::string, std::pair<int32_t, int32_t>>
+        &module_versions) {
+  ROS_INFO("-----------------check_module_versions");
+  for (const auto &required_pair : REQUIRED_MODULE_VERSIONS) {
+    const auto &module_name = required_pair.first;
+    const auto &required_version = required_pair.second;
+
+    const auto &actual_version_iter = module_versions.find(module_name);
+    if (actual_version_iter == module_versions.end()) {
+      ROS_WARN_STREAM("required server module " << module_name
+                                                << " not found!");
+      return false;
+    }
+    const auto &actual_version = actual_version_iter->second;
+    // major version number needs to match, minor version number equal or bigger
+    if ((actual_version.first == required_version.first) &&
+        (actual_version.second >= required_version.second)) {
+      ROS_DEBUG_STREAM("server module " << module_name << ": version ok!");
+    } else {
+      ROS_WARN_STREAM("---------8 module: "
+                      << module_name
+                      << " required version: " << required_version.first << "."
+                      << required_version.second
+                      << " (actual version: " << actual_version.first << "."
+                      << actual_version.second << ")");
+      return false;
+    }
+  }
+  return true;
+}
+
+bool ServerBridgeNode::serverMapListCb(
+    bosch_locator_bridge::ServerMapList::Request &req,
+    bosch_locator_bridge::ServerMapList::Response &res) {
+  auto query = server_interface_->getSessionQuery();
+  auto response = server_interface_->call("serverMapList", query);
+  if (response.has("serverMapNames")) {
+    const auto entries = response.getArray("serverMapNames");
+    for (size_t i = 0; i < entries->size(); i++) {
+      res.names.push_back(entries->get(i).toString());
+    }
+  }
+  return true;
+}
+
+bool ServerBridgeNode::serverMapGetImageWithResolutionCb(
+    bosch_locator_bridge::ServerMapGetImageWithResolution::Request &req,
+    bosch_locator_bridge::ServerMapGetImageWithResolution::Response &res) {
+
+  auto query = server_interface_->getSessionQuery();
+  query.set("resolution", req.resolution);
+  query.set("serverMapName", req.map_name);
+
+  auto response =
+      server_interface_->call("serverMapGetImageWithResolution", query);
+
+  if (response.getValue<double>("responseCode") == CommonResponseCode::OK) {
+    const auto &pose_2d = response.getObject("MAPimageOrigin");
+    const double &x = pose_2d->getValue<double>("x");
+    const double &y = pose_2d->getValue<double>("y");
+    const double &a = pose_2d->getValue<double>("a");
+    const double &width = response.getValue<double>("width");
+    const double &height = response.getValue<double>("height");
+
+    const std::string &encoded_png =
+        response.getObject("image")->getValue<std::string>("content");
+
+    std::istringstream png_stream(encoded_png);
+    Poco::Base64Decoder decoder(png_stream);
+
+    ROS_INFO_STREAM("Received map with origin x " << x << "y " << y << "a " << a
+                                                  << "\nheight " << height
+                                                  << "width " << width);
+    std::ofstream file;
+    file.exceptions(std::ofstream::failbit | std::ofstream::badbit);
+    try {
+      file.open(req.file_name + ".png", std::ios::binary);
+      file << decoder.rdbuf();
+      file.close();
+
+      file.open(req.file_name + ".yaml");
+      file << "image: " << req.file_name + ".png"
+           << "\nresolution: " << 1.0 / req.resolution << "\norigin: ["
+           << std::fixed << std::setprecision(6) << x << ", " << y << ", " << a
+           << "]\nnegate: "
+              "0\noccupied_thresh: 0.65\nfree_thresh: 0.196\n\n";
+    } catch (std::ofstream::failure &ex) {
+      ROS_ERROR_STREAM("Exception occured while writing: "
+                       << ex.what() << " with code: " << ex.code());
+      return false;
+    }
+
+  } else {
+    return false;
+  }
+  return true;
+}

--- a/bosch_locator_bridge/src/server/server_main.cpp
+++ b/bosch_locator_bridge/src/server/server_main.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2021 - for information on the respective copyright owner
+// see the NOTICE file and/or the repository
+// https://github.com/boschglobal/locator_ros_bridge.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <ros/ros.h>
+
+#include "server/server_bridge_node.hpp"
+
+int main(int argc, char **argv) {
+  ros::init(argc, argv, "server_ros_bridge");
+  ServerBridgeNode node;
+  node.init();
+
+  ros::AsyncSpinner spinner(4);
+  spinner.start();
+  ros::waitForShutdown();
+
+  return 0;
+}

--- a/bosch_locator_bridge/srv/ServerMapGetImageWithResolution.srv
+++ b/bosch_locator_bridge/srv/ServerMapGetImageWithResolution.srv
@@ -1,0 +1,4 @@
+string file_name #destination to save png and yaml to (do not specify a file extension)
+uint32 resolution #pixel per meter
+string map_name #map name on map server
+---

--- a/bosch_locator_bridge/srv/ServerMapList.srv
+++ b/bosch_locator_bridge/srv/ServerMapList.srv
@@ -1,0 +1,2 @@
+---
+string[] names


### PR DESCRIPTION
Extend the bridge by adding a additional node to access the server:

- list server maps
- dowload and save the map as ROS-conform .png + .yaml files for the map_server package

Signed-off-by: Robert Willeit <fkml@gmx.de>