### PR TITLE
Try to stop everything before setting config list

### DIFF
--- a/.github/workflows/build_utils_galactic.yml
+++ b/.github/workflows/build_utils_galactic.yml
@@ -20,10 +20,10 @@ jobs:
         os: [ ubuntu-20.04 ]
         ros_distribution: [ galactic ]
     steps:
-    - uses: ros-tooling/setup-ros@v0.3
+    - uses: ros-tooling/setup-ros@v0.6
       with:
         required-ros-distributions: ${{ matrix.ros_distribution }}
-    - uses : ros-tooling/action-ros-ci@v0.2
+    - uses : ros-tooling/action-ros-ci@v0.3
       with:
         package-name: bosch_locator_bridge_utils
         vcs-repo-file-url: ''

--- a/.github/workflows/build_utils_galactic.yml
+++ b/.github/workflows/build_utils_galactic.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: ros-tooling/setup-ros@v0.5
       with:
         required-ros-distributions: ${{ matrix.ros_distribution }}
-    - uses : ros-tooling/action-ros-ci@v0.2.7
+    - uses : ros-tooling/action-ros-ci@v0.2
       with:
         package-name: bosch_locator_bridge_utils
         vcs-repo-file-url: ''

--- a/.github/workflows/build_utils_galactic.yml
+++ b/.github/workflows/build_utils_galactic.yml
@@ -20,7 +20,7 @@ jobs:
         os: [ ubuntu-20.04 ]
         ros_distribution: [ galactic ]
     steps:
-    - uses: ros-tooling/setup-ros@v0.6
+    - uses: ros-tooling/setup-ros@v0.5
       with:
         required-ros-distributions: ${{ matrix.ros_distribution }}
     - uses : ros-tooling/action-ros-ci@v0.3

--- a/.github/workflows/build_utils_galactic.yml
+++ b/.github/workflows/build_utils_galactic.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: ros-tooling/setup-ros@v0.5
       with:
         required-ros-distributions: ${{ matrix.ros_distribution }}
-    - uses : ros-tooling/action-ros-ci@v0.3
+    - uses : ros-tooling/action-ros-ci@v0.2.7
       with:
         package-name: bosch_locator_bridge_utils
         vcs-repo-file-url: ''

--- a/bosch_locator_bridge/include/bosch_locator_bridge/locator_rpc_interface.hpp
+++ b/bosch_locator_bridge/include/bosch_locator_bridge/locator_rpc_interface.hpp
@@ -42,7 +42,7 @@ public:
   std::unordered_map<std::string, std::pair<int32_t, int32_t>> getAboutModules();
 
   Poco::DynamicStruct getConfigList();
-  void setConfigList(const Poco::DynamicStruct & config);
+  bool setConfigList(const Poco::DynamicStruct & config);
 
   Poco::JSON::Object getSessionQuery() const;
   Poco::JSON::Object call(const std::string & method, const Poco::JSON::Object & query_obj);

--- a/bosch_locator_bridge/src/locator_bridge_node.cpp
+++ b/bosch_locator_bridge/src/locator_bridge_node.cpp
@@ -562,7 +562,10 @@ void LocatorBridgeNode::syncConfig()
 
   if (!loc_client_interface_->setConfigList(loc_client_config)) {
     // Try to stop everything before setting config list
-    // TODO( ): Better use ClientControlMode interface to check the current operating mode
+    RCLCPP_WARN(
+      get_logger(),
+      "One of the modes appears to be in a RUN-state. In order to set the configuration parameters,"
+      " all modes are now stopped! Localization is started afterwards automatically.");
     clientRecordingStopVisualRecordingCb(nullptr, nullptr);
     clientMapStopCb(nullptr, nullptr);
     clientLocalizationStopCb(nullptr, nullptr);

--- a/bosch_locator_bridge/src/locator_bridge_node.cpp
+++ b/bosch_locator_bridge/src/locator_bridge_node.cpp
@@ -562,7 +562,7 @@ void LocatorBridgeNode::syncConfig()
 
   if (!loc_client_interface_->setConfigList(loc_client_config)) {
     // Try to stop everything before setting config list
-    // TODO: Better use ClientControlMode interface to check the current operating mode
+    // TODO( ): Better use ClientControlMode interface to check the current operating mode
     clientRecordingStopVisualRecordingCb(nullptr, nullptr);
     clientMapStopCb(nullptr, nullptr);
     clientLocalizationStopCb(nullptr, nullptr);

--- a/bosch_locator_bridge/src/locator_bridge_node.cpp
+++ b/bosch_locator_bridge/src/locator_bridge_node.cpp
@@ -560,7 +560,14 @@ void LocatorBridgeNode::syncConfig()
     provide_odometry_data_ = false;
   }
 
-  loc_client_interface_->setConfigList(loc_client_config);
+  if (!loc_client_interface_->setConfigList(loc_client_config)) {
+    // Try to stop everything before setting config list
+    // TODO: Better use ClientControlMode interface to check the current operating mode
+    clientRecordingStopVisualRecordingCb(nullptr, nullptr);
+    clientMapStopCb(nullptr, nullptr);
+    clientLocalizationStopCb(nullptr, nullptr);
+    loc_client_interface_->setConfigList(loc_client_config);
+  }
 }
 
 void LocatorBridgeNode::checkLaserScan(

--- a/bosch_locator_bridge/src/locator_rpc_interface.cpp
+++ b/bosch_locator_bridge/src/locator_rpc_interface.cpp
@@ -152,10 +152,15 @@ Poco::DynamicStruct LocatorRPCInterface::getConfigList()
   return config;
 }
 
-void LocatorRPCInterface::setConfigList(const Poco::DynamicStruct & config)
+bool LocatorRPCInterface::setConfigList(const Poco::DynamicStruct & config)
 {
-  auto config_resp =
+  try {
     json_rpc_call(session_, "configSet", makeConfigEntryArrayMessage(session_id_, config));
+  } catch (const std::runtime_error & error) {
+    std::cerr << error.what() << std::endl;
+    return false;
+  }
+  return true;
 }
 
 Poco::JSON::Object LocatorRPCInterface::call(


### PR DESCRIPTION
**Problem:**
The bridge tries to set the config parameters when starting. When the localization (or something else) is already running at the beginning, setting config parameters at the same time is not possible in the Locator, and the bridge crashes. To fix this, you have to use, for example, the aXessor.

**Solution:**
Try to stop everything before setting the parameters.

**Better solution:**
Instead of just trying to stop everything, it would be better to check the state of the Locator before. But information at the ClientControlMode interface is only available at state changes. Is there another API for checking the states, @syyuen, @HWasserfuhr ?