### PR TITLE
Make minRange non-negative

### DIFF
--- a/bosch_locator_bridge/src/rosmsgs_datagram_converter.cpp
+++ b/bosch_locator_bridge/src/rosmsgs_datagram_converter.cpp
@@ -483,7 +483,7 @@ Poco::Buffer<char> RosMsgsDatagramConverter::convertLaserScan2DataGram(
   // angleInc
   writer << static_cast<float>(msg->angle_increment);
   // minRange
-  writer << static_cast<float>(msg->range_min);
+  writer << static_cast<float>(std::max(0., msg->range_min));
   // maxRange
   writer << static_cast<float>(msg->range_max);
   // ranges.length

--- a/bosch_locator_bridge/src/rosmsgs_datagram_converter.cpp
+++ b/bosch_locator_bridge/src/rosmsgs_datagram_converter.cpp
@@ -483,7 +483,7 @@ Poco::Buffer<char> RosMsgsDatagramConverter::convertLaserScan2DataGram(
   // angleInc
   writer << static_cast<float>(msg->angle_increment);
   // minRange
-  writer << static_cast<float>(std::max(0., msg->range_min));
+  writer << static_cast<float>(std::max(0.0f, msg->range_min));
   // maxRange
   writer << static_cast<float>(msg->range_max);
   // ranges.length


### PR DESCRIPTION
In order to tolerate SICK picoScan150, which could produce LaserScan messages with little negative minRange, and avoid minRange validation failure errors raised by ROKIT Locator. Contributed by Fleer David.