### PR TITLE
Update README.md to include Locator 1.9

### DIFF
--- a/bosch_locator_bridge/README.md
+++ b/bosch_locator_bridge/README.md
@@ -9,7 +9,7 @@ It translates ROS 1 messages to the ROKIT Locator API (as described in the ROKIT
 It also allows to control the ROKIT Locator via ROS 1 service calls.
 
 The package has been tested under [ROS 1] Noetic and Ubuntu 20.04.
-The bridge is compatible with ROKIT Locator version 1.8.
+The bridge is compatible with ROKIT Locator version 1.9.
 If you have an earlier version, see [Support of earlier versions of ROKIT Locator](#support-of-earlier-versions-of-rokit-locator).
 
 ## Quick Start
@@ -352,7 +352,11 @@ To avoid this, make sure `LaserScan` messages are sent to the bridge before swit
 
 ## Support of earlier versions of ROKIT Locator
 
-If you have version 1.6 of ROKIT Locator, checkout the corresponding tag:
+If you have version 1.8 of ROKIT Locator, checkout the corresponding tag:
+
+    git checkout 1.0.10 -b noetic-v1.8
+
+And if you have version 1.6:
 
     git checkout 1.0.9 -b noetic-v1.6
 


### PR DESCRIPTION
Update README.md to state
- Latest commit of branch noetic works with ROKIT Locator 1.9
- Checkout tag 1.0.10 when using ROKIT Locator 1.8

Perhaps tag 1.0.10 should be reset onto a newer commit 11475a97b4d02eeda171b9cf5d4a77f7461d3cc9,
```bash
git tag 1.0.10 11475a97b4d02eeda171b9cf5d4a77f7461d3cc9 -f -am 1.0.10
git push -f origin 1.0.10
```