### PR TITLE
Add bosch_locator_bridge_utils backward compatibility for galactic

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It also allows to control the ROKIT Locator via ROS service calls.
 
 There are versions for the following ROS 1 and ROS 2 distributions:
 * ROS 1: Noetic (branch [noetic](../../tree/noetic), will likely also work on Melodic)
-* ROS 2: Humble (this branch)
+* ROS 2: Humble (this branch, will likely also work on Galactic)
 
 The repository also contains the [bosch_locator_bridge_utils](bosch_locator_bridge_utils) package, which provides an interface between the bosch_locator_bridge and [Nav2], the navigation stack of ROS 2.
 

--- a/bosch_locator_bridge_utils/CMakeLists.txt
+++ b/bosch_locator_bridge_utils/CMakeLists.txt
@@ -32,6 +32,10 @@ find_package(tf2_ros REQUIRED)
 find_package(PCL REQUIRED)
 include_directories(include ${PCL_INCLUDE_DIRS})
 
+if("$ENV{ROS_DISTRO}" STREQUAL "galactic")
+  add_compile_definitions(ROS_GALACTIC)
+endif()
+
 add_executable(locator_map_server src/map_server_main.cpp src/map_server.cpp)
 target_include_directories(locator_map_server PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/${PROJECT_NAME}>

--- a/bosch_locator_bridge_utils/include/bosch_locator_bridge_utils/locator_node.hpp
+++ b/bosch_locator_bridge_utils/include/bosch_locator_bridge_utils/locator_node.hpp
@@ -27,7 +27,11 @@
 #include "tf2_ros/transform_broadcaster.h"
 #include "tf2_ros/transform_listener.h"
 #include "tf2_ros/create_timer_ros.h"
-#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#ifdef ROS_GALACTIC
+  #include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+#else
+  #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#endif
 
 namespace bosch_locator_bridge_utils
 {


### PR DESCRIPTION
The bosch_locator_bridge_utils still build on galactic if the old tf2 includes are used.