### PR TITLE
CMake: fix boost system

### DIFF
--- a/bosch_locator_bridge/CMakeLists.txt
+++ b/bosch_locator_bridge/CMakeLists.txt
@@ -68,7 +68,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
 
 ament_export_dependencies(rosidl_default_runtime)
 
-find_package(Boost REQUIRED)
 find_package(PCL REQUIRED)
 include_directories(SYSTEM ${PCL_INCLUDE_DIRS})
 
@@ -83,7 +82,6 @@ set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX ""
 target_include_directories(${PROJECT_NAME}_node PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/${PROJECT_NAME}>
   $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
-target_link_libraries(${PROJECT_NAME}_node  ${Boost_LIBRARIES})
 ament_target_dependencies(${PROJECT_NAME}_node
   rclcpp
   geometry_msgs
@@ -112,7 +110,6 @@ set_target_properties(${PROJECT_NAME}_server_node PROPERTIES OUTPUT_NAME server_
 target_include_directories(${PROJECT_NAME}_server_node PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/${PROJECT_NAME}>
   $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
-target_link_libraries(${PROJECT_NAME}_server_node  ${Boost_LIBRARIES})
 ament_target_dependencies(${PROJECT_NAME}_server_node
   rclcpp
   std_srvs

--- a/bosch_locator_bridge/CMakeLists.txt
+++ b/bosch_locator_bridge/CMakeLists.txt
@@ -68,7 +68,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
 
 ament_export_dependencies(rosidl_default_runtime)
 
-find_package(Boost REQUIRED COMPONENTS system)
+find_package(Boost REQUIRED)
 find_package(PCL REQUIRED)
 include_directories(SYSTEM ${PCL_INCLUDE_DIRS})
 


### PR DESCRIPTION
Hi,

This fix for boost >= 1.89:
```cmake
CMake Error at /nix/store/f1jzlprx190bfspq1i56bd0r8q9lwy0x-boost-1.89.0-dev/lib/cmake/Boost-1.89.0/BoostConfig.cmake:141 (find_package):
  Could not find a package configuration file provided by "boost_system"
  (requested version 1.89.0) with any of the following names:

    boost_systemConfig.cmake
    boost_system-config.cmake

  Add the installation prefix of "boost_system" to CMAKE_PREFIX_PATH or set
  "boost_system_DIR" to a directory containing one of the above files.  If
  "boost_system" provides a separate development package or SDK, be sure it
  has been installed.
Call Stack (most recent call first):
  /nix/store/f1jzlprx190bfspq1i56bd0r8q9lwy0x-boost-1.89.0-dev/lib/cmake/Boost-1.89.0/BoostConfig.cmake:262 (boost_find_component)
  /nix/store/v2i1hgv567g3v91im5x4g5bff52143i0-cmake-4.1.2/share/cmake-4.1/Modules/FindBoost.cmake:609 (find_package)
  CMakeLists.txt:71 (find_package)
```

boost system has been header only since release 1.69 (December 5, 2018), and a useless stub was provided instead.

in 1.89 (August 6, 2025), that stub was removed, so CMake fail if we require it.

ref. https://www.boost.org/doc/libs/latest/libs/system/doc/html/system.html#changes_in_boost_1_89