### PR TITLE
Add nav2 common dependency

### DIFF
--- a/bosch_locator_bridge_utils/package.xml
+++ b/bosch_locator_bridge_utils/package.xml
@@ -12,7 +12,7 @@
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>nav2_util</depend>
-   <exec_depend>nav2_common</exec_depend>
+  <exec_depend>nav2_common</exec_depend>
   <depend>pcl_conversions</depend>
   <depend>rclcpp</depend>
   <depend>std_srvs</depend>

--- a/bosch_locator_bridge_utils/package.xml
+++ b/bosch_locator_bridge_utils/package.xml
@@ -12,6 +12,7 @@
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>nav2_util</depend>
+   <exec_depend>nav2_common</exec_depend>
   <depend>pcl_conversions</depend>
   <depend>rclcpp</depend>
   <depend>std_srvs</depend>


### PR DESCRIPTION
This PR declares `nav2_common` as an explicit runtime dependency of `bosch_locator_bridge_utils`.

`launch/localization_launch.py` directly imports `RewrittenYaml` from `nav2_common.launch` and instantiates it while generating the launch description. Currently, `nav2_common` appears to be available transitively through `nav2_util`, but the direct runtime usage is not reflected in `package.xml`.

This PR adds:

```xml
<exec_depend>nav2_common</exec_depend>
```

No CMake change is needed because `nav2_common` is used only by the installed Python launch file and is not consumed by either C++ target.