### PR TITLE
Use the same version for navigator bridge

### DIFF
--- a/bosch_navigator_bridge/package.xml
+++ b/bosch_navigator_bridge/package.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <package format="3"> 
   <name>bosch_navigator_bridge</name>
-  <version>1.0.0</version>
+  <version>2.1.15</version>
   <description>ROS interface to Rexroth ROKIT Navigator</description>
-  <maintainer email="Jasmin.Hoegel@boschrexroth.de">hoj1ul</maintainer>
+  <maintainer email="Fabian.Koenig@boschrexroth.de">Fabian Koenig</maintainer>
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>


### PR DESCRIPTION
All packages in the repos must have the same version number.